### PR TITLE
Taking rules only with atleast three values in metadata

### DIFF
--- a/yara_integration/yara_python_script.py
+++ b/yara_integration/yara_python_script.py
@@ -21,7 +21,7 @@ rules_dirs = ["crowd_sourced_yara_rules", "custom_yara_rules"]
 #inp_file = sys.argv[2] 
 
 def mycallback(data):
-    if data['meta']:
+    if data['meta'] and len(data['meta']) >=3 :
         matched_rules[data['rule']] = data['meta']
     return yara.CALLBACK_CONTINUE
 


### PR DESCRIPTION
Filtering out Yara rules that don't have at least three values in their meta-data 